### PR TITLE
Release 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-alias-manager",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "git-alias-manager",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "inquirer": "^14.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-alias-manager",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GAM (Git Alias Manager) is a NodeJS application for managing multiple Git accounts (aliases).",
   "main": "./src/methods.js",
   "scripts": {


### PR DESCRIPTION
`master` is 14 commits ahead of the `1.3.0` tag, and every one of them touches only `package.json` or `package-lock.json`. The published release is from **25 November 2022**, so `npm install -g git-alias-manager` currently gets a tree three years of transitive advisories behind this branch.

This bumps the version so the accumulated fixes can actually ship.

## What is already on master since 1.3.0

- json5 1.0.1 to 1.0.2
- word-wrap 1.2.3 to 1.2.4
- flatted 3.2.7 to 3.4.4
- js-yaml 4.1.0 to 4.3.1
- brace-expansion 1.1.11 to 1.1.18
- lodash 4.17.21 to 4.18.1
- tmp and inquirer

All transitive, all dependabot, no source changes. That makes this a patch release rather than a minor one.

## The change here

`npm version patch --no-git-tag-version`, which updates `package.json` and both version fields in `package-lock.json`. Nothing else.

## After merge

The release still has to be created and the tag pushed:

```bash
gh release create v1.3.1 --repo Megapixel99/GAM --target master --title "v1.3.1"
```

Worth noting that the existing tags are inconsistent: sixteen of them are `vX.Y.Z` and the newest, `1.3.0`, is not. `v1.3.1` follows the majority.

Publishing to npm is a separate step and is your call, not something this PR does.