### PR TITLE
Gate the git-config check on the commands that need it, and fail non-zero

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -21,10 +21,21 @@ const bits = (args.includes('b') || args.includes('bits'))
 const dir = (args.includes('d') || args.includes('directory'))
   ? ((args[args.indexOf('directory')] && args[args.indexOf('directory') + 1]) || (args[args.indexOf('b')] && args[args.indexOf('b') + 1])) : path.join(require('os').homedir(), '/.ssh');
 
-if (!fs.existsSync(path.join(require('os').homedir(), '.gitconfig'))) {
-  console.log('Could not find a git configuration for the current user, please dowload git and try again');
-  console.log('exiting program');
-  process.exit(0);
+// Called only by the commands that actually read or write the user's global git
+// config. It is deliberately not a load-time check: `version` and `help` need no git
+// configuration at all, and a tool that refuses to say what version it is until a git
+// identity exists is broken rather than careful. The commands that only touch SSH
+// keys under `dir` (create-alias, delete-alias, alias-email, backup) do not need one
+// either, so gating them here would be the same mistake in a smaller place.
+//
+// Exits non-zero: this is a fatal precondition failure, and a caller that checks the
+// status must not read "refused to start" as success.
+function requireGitConfig() {
+  if (!fs.existsSync(path.join(require('os').homedir(), '.gitconfig'))) {
+    console.error('Could not find a git configuration for the current user, please download git and try again');
+    console.error('exiting program');
+    process.exit(1);
+  }
 }
 
 if (args[0] === 'create-alias') {
@@ -40,6 +51,8 @@ if (args[0] === 'create-alias') {
     });
   });
 } else if (args[0] === 'change-alias') {
+  // changeGlobalEmail() rewrites ~/.gitconfig.
+  requireGitConfig();
   if (!alias) {
     methods.chooseAlias(' to use', dir).then(async (_alias) => {
       methods.changeAlias(_alias, dir).then((newAlias) => {
@@ -78,6 +91,8 @@ if (args[0] === 'create-alias') {
     });
   }
 } else if (args[0] === 'current-alias-email') {
+  // currentAliasEmail() reads ~/.gitconfig directly and would throw ENOENT without it.
+  requireGitConfig();
   const emails = methods.currentAliasEmail();
   console.log('Current Alias Info:' + '\n'
         + '  ' + 'Global:' + '\n'

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,9 +1,13 @@
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const assert = require('assert');
+const { spawnSync } = require('child_process');
 const methods = require('../src/methods.js');
+const packageVersion = require('../package.json').version;
 
 const dir = path.join(__dirname, 'test');
+const managerPath = path.join(__dirname, '..', 'src', 'manager.js');
 const isSupported = process.platform !== 'win32' || process.env.CI || process.env.TERM === 'xterm-256color';
 const checkMark = isSupported ? '✔︎' : '√';
 const xMark = isSupported ? '✖' : '×';
@@ -65,6 +69,31 @@ function testFunction(testobj) {
   });
 }
 
+// Runs the CLI the way a user does — as a program — with HOME pointed at an empty
+// directory, so ~/.gitconfig does not exist. Requiring the module would not test this:
+// manager.js reads process.argv and dispatches while it loads, so only spawning it
+// exercises the path a caller hits. The exit status is returned alongside the output
+// because both are part of what the CLI promises.
+function runCli(args) {
+  const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'gam-no-gitconfig-'));
+  try {
+    const res = spawnSync(process.execPath, [managerPath].concat(args), {
+      encoding: 'utf8',
+      // USERPROFILE as well as HOME: os.homedir() reads that one on Windows.
+      env: { ...process.env, HOME: emptyHome, USERPROFILE: emptyHome },
+    });
+    return {
+      status: res.status,
+      stdout: res.stdout || '',
+      stderr: res.stderr || '',
+    };
+  } finally {
+    fs.rmSync(emptyHome, { recursive: true, force: true });
+  }
+}
+
+const refusedRegex = /Could not find a git configuration/;
+
 function runTests() {
   return new Promise(async (resolve, reject) => {
     await testPromise({
@@ -114,6 +143,51 @@ function runTests() {
       params: ['alias', dir],
       expected: 'alias',
       name: 'Deleting another alias',
+    });
+    // The CLI itself, with no git configuration present. `version` and `help` need
+    // none, so they must answer normally; the commands that read ~/.gitconfig must
+    // refuse — and must exit NON-ZERO when they do, so a caller checking the status
+    // does not read "refused to start" as success.
+    await testFunction({
+      func: () => {
+        const res = runCli(['version']);
+        return {
+          status: res.status,
+          reportsVersion: res.stdout.includes(`Current version: ${packageVersion}`),
+          refused: refusedRegex.test(res.stdout + res.stderr),
+        };
+      },
+      params: [],
+      expected: { status: 0, reportsVersion: true, refused: false },
+      name: '`version` answers without a git config, and exits 0',
+    });
+    await testFunction({
+      func: () => {
+        const res = runCli(['help']);
+        return {
+          status: res.status,
+          printsUsage: res.stdout.includes('Usage: gam'),
+          refused: refusedRegex.test(res.stdout + res.stderr),
+        };
+      },
+      params: [],
+      expected: { status: 0, printsUsage: true, refused: false },
+      name: '`help` answers without a git config, and exits 0',
+    });
+    await testFunction({
+      func: () => {
+        const res = runCli(['current-alias-email']);
+        const output = res.stdout + res.stderr;
+        return {
+          status: res.status,
+          refused: refusedRegex.test(output),
+          // The wording is checked too, so the 'dowload' typo cannot come back.
+          saysDownload: output.includes('please download git and try again'),
+        };
+      },
+      params: [],
+      expected: { status: 1, refused: true, saysDownload: true },
+      name: '`current-alias-email` refuses without a git config, and exits non-zero',
     });
     resolve();
   });


### PR DESCRIPTION
`src/manager.js` checked for `~/.gitconfig` at load time, before any argument handling. Two defects came out of that.

**It gated every subcommand**, including `version` and `help`, which need no git configuration at all. This surfaced in CI: a fresh runner has no `~/.gitconfig` — `actions/checkout` writes repository-local config only — so `node ./src/manager.js version` printed the refusal instead of the version.

**It exited 0 on a fatal precondition failure**, so any caller checking the exit status read "refused to start" as success. That is why the checks in `ci.yml` and `release.yml` assert on stdout rather than on the exit status.

## The change

The check is now `requireGitConfig()`, called from the two commands that actually read or write the global git config:

| Command | Why it needs one |
| --- | --- |
| `change-alias` | `changeGlobalEmail()` rewrites `~/.gitconfig` |
| `current-alias-email` | `getCurrentEmail()` reads it, and would throw `ENOENT` |

It exits **1**, writes to stderr, and the `dowload` typo is fixed.

**One deviation from the suggested fix worth review.** The suggestion said to gate "the alias operations"; this gates only those two rather than all six. `create-alias`, `delete-alias`, `alias-email`, and `backup` only touch SSH keys under `dir` — each was checked against `methods.js`, and none consults a git config. Gating them would be the original defect again in a smaller place. The reasoning is recorded in a comment, so it is easy to widen if you disagree.

## Tests

Nothing in the suite ran the CLI as a program, which is exactly where both defects lived: `manager.js` reads `process.argv` and dispatches while it loads, so requiring the module never exercises the path a user hits.

`runCli()` spawns it with `HOME` pointed at an empty temp dir (and `USERPROFILE`, which is what `os.homedir()` reads on Windows) and returns the exit status alongside the output. Three cases:

- `version` answers normally, exits 0, does not refuse
- `help` answers normally, exits 0, does not refuse
- `current-alias-email` refuses, exits 1, and the message wording is asserted so the typo cannot come back

## Verification

- Suite passes 10/10 and leaves the tree clean.
- **All three new cases fail against the previous code** — verified by running the same commands against `HEAD`'s `manager.js`, where each refuses with exit 0 and the typo.
- Happy path unchanged: `current-alias-email` in a normal repo with a gitconfig still prints both emails and exits 0.
- No new lint findings. The repo does not lint clean to begin with (16 pre-existing errors); this was diffed against that baseline and the two newly introduced were fixed.

## Two notes

**The workflows are not on this branch.** `.github/` does not exist here or on `master` — `ci.yml` and `release.yml` live only on `origin/claude/npm-release-publish-action-7ad039`, and were read from there. No edit was needed: both assert on stdout with `grep -q "Current version: $expected"` and `grep -q 'Usage: gam'`, and that output is unchanged, so they keep passing. Their `git config --global` steps still do real work for the alias subcommands. Once this lands, the comments in both files explaining *why* output is asserted instead of exit status become wrong — a follow-up on that branch, where the checks could now be tightened to assert exit status.

**Base branch.** CONTRIBUTING.md asks for work to branch off `develop`, but `develop` is currently 24 commits behind `master` and contains nothing `master` does not, so targeting it would drag all 24 into this diff. Retarget if you prefer.

## Out of scope

While testing the pass-through path, an unhandled `ENOTDIR` turned up in `current-alias-email`: `methods.js` reads `.git/config` unconditionally, but in a git worktree `.git` is a file, so it stack-traces — same crash in any non-repo directory (`ENOENT`). It reproduces identically on `master` and is unrelated to this change; `changeLocalEmail()` already guards the same path correctly, the read path just does not. Left alone rather than widening this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)